### PR TITLE
Remove superfluous sudo commands

### DIFF
--- a/install_puppet.sh
+++ b/install_puppet.sh
@@ -4,16 +4,16 @@ if grep Ubuntu /etc/*-release &>/dev/null ; then
   for release in trusty precise ; do
     if grep $release /etc/*-release &>/dev/null ; then
       wget -O /tmp/puppetlabs-release-${release}.deb https://apt.puppetlabs.com/puppetlabs-release-${release}.deb
-      sudo dpkg -i /tmp/puppetlabs-release-${release}.deb
+      dpkg -i /tmp/puppetlabs-release-${release}.deb
       rm /tmp/puppetlabs-release-${release}.deb
     fi
   done
-  sudo apt-get update
+  apt-get update
   apt-get install -y puppet
 elif grep "\(CentOS\|RedHat\)" /etc/*-release &>/dev/null ; then
   for release in 5 6 7 ; do
     if grep "release $release" /etc/*-release &>/dev/null ; then
-      sudo rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-${release}.noarch.rpm
+      rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-el-${release}.noarch.rpm
       yum install -y puppet
       break
     fi


### PR DESCRIPTION
This script made inconsistent use of the sudo command. This change
removes all use of sudo since previously it had to be run as root
anyway.